### PR TITLE
feat: Multiple devices 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This code is a detached fork of [SAEVis](https://github.com/callummcdougall/sae_vis/tree/main) and is a work in progress. Please bare with us while we develop it further. 
 
+# TODO:
+
+- [ ] set up GPU CI server so we can test things like mult-GPU generation.
+- [ ] Profile code with multiple GPU's to improve efficiency.
+- [ ] Work out a way to parallelize feature generation accross jobs so we can get this all moving much faster. 
+
+
 # OLD README
 
 This codebase was designed to replicate Anthropic's sparse autoencoder visualisations, which you can see [here](https://transformer-circuits.pub/2023/monosemantic-features/vis/a1.html). The codebase provides 2 different views: a **feature-centric view** (which is like the one in the link, i.e. we look at one particular feature and see things like which tokens fire strongest on that feature) and a **prompt-centric view** (where we look at once particular prompt and see which features fire strongest on that prompt according to a variety of different metrics).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ rich = "^13.7.1"
 matplotlib = "^3.8.4"
 safetensors = "^0.4.3"
 typer = "^0.12.3"
-sae-lens = "^3.2.2"
+sae-lens = "^3.5.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.3.7"
@@ -35,7 +35,7 @@ black = "^24.4.2"
 
 [tool.isort]
 profile = "black"
-src_paths = ["sae_lens", "tests"]
+src_paths = ["sae_dashboard", "tests"]
 
 [tool.pyright]
 typeCheckingMode = "strict"

--- a/sae_dashboard/components.py
+++ b/sae_dashboard/components.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 
 import numpy as np
 from dataclasses_json import dataclass_json
+
 from sae_dashboard.components_config import (
     ActsHistogramConfig,
     FeatureTablesConfig,

--- a/sae_dashboard/data_parsing_fns.py
+++ b/sae_dashboard/data_parsing_fns.py
@@ -3,13 +3,14 @@ import numpy as np
 import torch
 from eindex import eindex
 from jaxtyping import Float, Int
+from sae_lens import SAE
+from torch import Tensor
+from transformer_lens import HookedTransformer, utils
+
 from sae_dashboard.components import LogitsTableData, SequenceData
 from sae_dashboard.sae_vis_data import SaeVisData
 from sae_dashboard.transformer_lens_wrapper import TransformerLensWrapper, to_resid_dir
 from sae_dashboard.utils_fns import RollingCorrCoef, TopK
-from sae_lens import SAE
-from torch import Tensor
-from transformer_lens import HookedTransformer, utils
 
 Arr = np.ndarray
 
@@ -79,7 +80,7 @@ def add_neuron_alignment_data(
     feature_tables_data: dict[str, list[list[int]] | list[list[float]]],
     n_rows: int,
 ):
-    top3_neurons_aligned = TopK(tensor=feature_out_dir, k=n_rows, largest=True)
+    top3_neurons_aligned = TopK(tensor=feature_out_dir.float(), k=n_rows, largest=True)
     feature_out_l1_norm = feature_out_dir.abs().sum(dim=-1, keepdim=True)
     pct_of_l1: Arr = np.absolute(top3_neurons_aligned.values) / utils.to_numpy(
         feature_out_l1_norm
@@ -122,8 +123,8 @@ def add_encoder_B_feature_correlations(
 
 def get_logits_table_data(logit_vector: Float[Tensor, "d_vocab"], n_rows: int):
     # Get logits table data
-    top_logits = TopK(logit_vector, k=n_rows, largest=True)
-    bottom_logits = TopK(logit_vector, k=n_rows, largest=False)
+    top_logits = TopK(logit_vector.float(), k=n_rows, largest=True)
+    bottom_logits = TopK(logit_vector.float(), k=n_rows, largest=False)
 
     top_logit_values = top_logits.values.tolist()
     top_token_ids = top_logits.indices.tolist()

--- a/sae_dashboard/data_writing_fns.py
+++ b/sae_dashboard/data_writing_fns.py
@@ -2,11 +2,12 @@ import itertools
 from copy import deepcopy
 from pathlib import Path
 
+from tqdm.auto import tqdm
+
 from sae_dashboard.data_parsing_fns import get_prompt_data
 from sae_dashboard.html_fns import HTML
 from sae_dashboard.sae_vis_data import SaeVisData
 from sae_dashboard.utils_fns import get_decode_html_safe_fn
-from tqdm.auto import tqdm
 
 METRIC_TITLES = {
     "act_size": "Activation Size",

--- a/sae_dashboard/feature_data_generator.py
+++ b/sae_dashboard/feature_data_generator.py
@@ -5,15 +5,16 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from jaxtyping import Float, Int
-from sae_dashboard.sae_vis_data import SaeVisConfig
-from sae_dashboard.transformer_lens_wrapper import TransformerLensWrapper, to_resid_dir
-from sae_dashboard.utils_fns import RollingCorrCoef
 from sae_lens import SAE
 from sae_lens.config import DTYPE_MAP as DTYPES
 from safetensors import safe_open
 from safetensors.torch import save_file
 from torch import Tensor
 from tqdm.auto import tqdm
+
+from sae_dashboard.sae_vis_data import SaeVisConfig
+from sae_dashboard.transformer_lens_wrapper import TransformerLensWrapper, to_resid_dir
+from sae_dashboard.utils_fns import RollingCorrCoef
 
 Arr = np.ndarray
 
@@ -74,7 +75,7 @@ class FeatureDataGenerator:
             # Compute feature activations from this
             feature_acts = self.encoder.get_feature_acts_subset(
                 model_acts, feature_indices
-            )
+            ).to(DTYPES[self.cfg.dtype])
 
             self.update_rolling_coefficients(
                 model_acts=model_acts,

--- a/sae_dashboard/html_fns.py
+++ b/sae_dashboard/html_fns.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from matplotlib import colors
+
 from sae_dashboard.components_config import Column
 from sae_dashboard.utils_fns import apply_indent, deep_union
 

--- a/sae_dashboard/layout.py
+++ b/sae_dashboard/layout.py
@@ -3,6 +3,7 @@ from dataclasses import asdict, dataclass, field
 from dataclasses_json import dataclass_json
 from rich import print as rprint
 from rich.tree import Tree
+
 from sae_dashboard.components_config import (
     ActsHistogramConfig,
     BaseComponentConfig,

--- a/sae_dashboard/sae_vis_data.py
+++ b/sae_dashboard/sae_vis_data.py
@@ -6,11 +6,12 @@ from typing import Any, Iterable
 from dataclasses_json import dataclass_json
 from rich import print as rprint
 from rich.table import Table
+from sae_lens import SAE
+from transformer_lens import HookedTransformer
+
 from sae_dashboard.feature_data import FeatureData
 from sae_dashboard.layout import SaeVisLayoutConfig
 from sae_dashboard.utils_fns import FeatureStatistics
-from sae_lens import SAE
-from transformer_lens import HookedTransformer
 
 SAE_CONFIG_DICT = dict(
     hook_point="The hook point to use for the SAE",

--- a/sae_dashboard/sae_vis_runner.py
+++ b/sae_dashboard/sae_vis_runner.py
@@ -35,7 +35,8 @@ from sae_dashboard.utils_fns import FeatureStatistics
 class SaeVisRunner:
     def __init__(self, cfg: SaeVisConfig) -> None:
         self.cfg = cfg
-        self.device = DTYPES[self.cfg.dtype]
+        self.device = self.cfg.device
+        self.dtype = DTYPES[self.cfg.dtype]
         if self.cfg.cache_dir is not None:
             self.cfg.cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -102,7 +103,7 @@ class SaeVisRunner:
 
             # Get the logits of all features (i.e. the directions this feature writes to the logit output)
             logits = einops.einsum(
-                feature_resid_dir.to(model.W_U.dtype),
+                feature_resid_dir.to(device= model.W_U.device, dtype =model.W_U.dtype),
                 model.W_U,
                 "feats d_model, d_model d_vocab -> feats d_vocab",
             ).to(self.device)

--- a/sae_dashboard/sae_vis_runner.py
+++ b/sae_dashboard/sae_vis_runner.py
@@ -103,7 +103,7 @@ class SaeVisRunner:
 
             # Get the logits of all features (i.e. the directions this feature writes to the logit output)
             logits = einops.einsum(
-                feature_resid_dir.to(device= model.W_U.device, dtype =model.W_U.dtype),
+                feature_resid_dir.to(device=model.W_U.device, dtype=model.W_U.dtype),
                 model.W_U,
                 "feats d_model, d_model d_vocab -> feats d_vocab",
             ).to(self.device)

--- a/sae_dashboard/sae_vis_runner.py
+++ b/sae_dashboard/sae_vis_runner.py
@@ -1,7 +1,7 @@
 import math
 import random
 from collections import defaultdict
-from typing import Iterable, cast
+from typing import Iterable
 
 import einops
 import numpy as np
@@ -9,6 +9,12 @@ import torch
 from jaxtyping import Int
 from rich import print as rprint
 from rich.table import Table
+from sae_lens import SAE
+from sae_lens.config import DTYPE_MAP as DTYPES
+from torch import Tensor
+from tqdm.auto import tqdm
+from transformer_lens import HookedTransformer
+
 from sae_dashboard.components import (
     ActsHistogramData,
     FeatureTablesData,
@@ -24,17 +30,12 @@ from sae_dashboard.sae_vis_data import SaeVisConfig, SaeVisData
 from sae_dashboard.sequence_data_generator import SequenceDataGenerator
 from sae_dashboard.transformer_lens_wrapper import TransformerLensWrapper
 from sae_dashboard.utils_fns import FeatureStatistics
-from sae_lens import SAE
-from sae_lens.config import DTYPE_MAP as DTYPES
-from torch import Tensor
-from tqdm.auto import tqdm
-from transformer_lens import HookedTransformer
 
 
 class SaeVisRunner:
     def __init__(self, cfg: SaeVisConfig) -> None:
         self.cfg = cfg
-
+        self.device = DTYPES[self.cfg.dtype]
         if self.cfg.cache_dir is not None:
             self.cfg.cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -54,15 +55,15 @@ class SaeVisRunner:
         encoder.fold_W_dec_norm()
 
         # set precision on encoders and model
-        encoder = encoder.to(DTYPES[self.cfg.dtype])
-        model = cast(HookedTransformer, model.to(DTYPES[self.cfg.dtype]))
-        if encoder_B is not None:
-            encoder_B.to(DTYPES[self.cfg.dtype])
+        # encoder = encoder.to(DTYPES[self.cfg.dtype])
+        # # model = cast(HookedTransformer, model.to(DTYPES[self.cfg.dtype]))
+        # if encoder_B is not None:
+        #     encoder_B.to(DTYPES[self.cfg.dtype])
 
         # Create objects to store all the data we'll get from `_get_feature_data`
         sae_vis_data = SaeVisData(cfg=self.cfg)
-        model.to(self.cfg.device)
-        encoder = encoder.to(self.cfg.device)
+        # model.to(self.cfg.device)
+        # encoder = encoder.to(self.cfg.device)
         time_logs = defaultdict(float)
 
         features_list = self.handle_features(self.cfg.features, encoder)
@@ -101,10 +102,10 @@ class SaeVisRunner:
 
             # Get the logits of all features (i.e. the directions this feature writes to the logit output)
             logits = einops.einsum(
-                feature_resid_dir,
+                feature_resid_dir.to(model.W_U.dtype),
                 model.W_U,
                 "feats d_model, d_model d_vocab -> feats d_vocab",
-            )
+            ).to(self.device)
 
             # ! Get stats (including quantiles, which will be useful for the prompt-centric visualisation)
             feature_stats = FeatureStatistics.create(
@@ -266,7 +267,9 @@ class SaeVisRunner:
             """
             Get a subset of the feature activations for a dataset.
             """
-            return sae.encode(x)[..., feature_idx]
+            original_device = x.device
+            feature_activations = sae.encode(x.to(device=sae.device, dtype=sae.dtype))
+            return feature_activations[..., feature_idx].to(original_device)
 
         sae.get_feature_acts_subset = sae_lens_get_feature_acts_subset  # type: ignore
 

--- a/sae_dashboard/utils_fns.py
+++ b/sae_dashboard/utils_fns.py
@@ -857,6 +857,8 @@ class RollingCorrCoef:
         self,
         indices: list[int] | None = None,
         with_self: bool = False,
+        dtype: torch.dtype = torch.float32,
+        device: torch.device = torch.device("cpu"),
     ) -> None:
         """
         Args:
@@ -872,6 +874,8 @@ class RollingCorrCoef:
         self.Y = None
         self.indices = indices
         self.with_self = with_self
+        self.dtype = dtype
+        self.device = device
 
     def update(self, x: Float[Tensor, "X N"], y: Float[Tensor, "Y N"]) -> None:
         # Get values of x and y, and check for consistency with each other & with previous values
@@ -894,14 +898,17 @@ class RollingCorrCoef:
         self.X = X
         self.Y = Y
 
+        x = x.to(dtype=self.dtype, device=self.device)
+        y = y.to(dtype=self.dtype, device=self.device)
+
         # If this is the first update step, then we need to initialise the sums
         if self.n == 0:
-            self.x_sum = torch.zeros(X, device=x.device)
-            self.xy_sum = torch.zeros(X, Y, device=x.device)
-            self.x2_sum = torch.zeros(X, device=x.device)
+            self.x_sum = torch.zeros(X, device=x.device, dtype=self.dtype)
+            self.xy_sum = torch.zeros(X, Y, device=x.device, dtype=self.dtype)
+            self.x2_sum = torch.zeros(X, device=x.device, dtype=self.dtype)
             if not self.with_self:
-                self.y_sum = torch.zeros(Y, device=y.device)
-                self.y2_sum = torch.zeros(Y, device=y.device)
+                self.y_sum = torch.zeros(Y, device=y.device, dtype=self.dtype)
+                self.y2_sum = torch.zeros(Y, device=y.device, dtype=self.dtype)
 
         # Next, update the sums
         self.n += x.shape[-1]

--- a/sae_dashboard_demo_mistral.ipynb
+++ b/sae_dashboard_demo_mistral.ipynb
@@ -1,0 +1,251 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo Notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Steps:\n",
+    "1. Download SAE with SAE Lens.\n",
+    "2. Create a dataset consistent with that SAE. \n",
+    "3. Fold the SAE decoder norm weights so that feature activations are \"correct\".\n",
+    "4. Estimate the activation normalization constant if needed, and fold it into the SAE weights.\n",
+    "5. Run the SAE generator for the features you want."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Set Up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformer_lens import HookedTransformer\n",
+    "from sae_lens import ActivationsStore, SAE\n",
+    "from importlib import reload\n",
+    "import sae_dashboard\n",
+    "\n",
+    "reload(sae_dashboard)\n",
+    "\n",
+    "if torch.backends.mps.is_available():\n",
+    "    device = \"mps\"\n",
+    "else:\n",
+    "    device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "\n",
+    "print(f\"Device: {device}\")\n",
+    "\n",
+    "model = HookedTransformer.from_pretrained(\"mistral-7b\", device = device, n_devices = 4, dtype=\"bfloat16\")\n",
+    "\n",
+    "# the cfg dict is returned alongside the SAE since it may contain useful information for analysing the SAE (eg: instantiating an activation store)\n",
+    "# Note that this is not the same as the SAEs config dict, rather it is whatever was in the HF repo, from which we can extract the SAE config dict\n",
+    "# We also return the feature sparsities which are stored in HF for convenience. \n",
+    "sae, cfg_dict, sparsity = SAE.from_pretrained(\n",
+    "    release = \"mistral-7b-res-wg\", # see other options in sae_lens/pretrained_saes.yaml\n",
+    "    sae_id = \"blocks.8.hook_resid_pre\", # won't always be a hook point\n",
+    "    device = \"cuda:3\",\n",
+    ")\n",
+    "# fold w_dec norm so feature activations are accurate\n",
+    "sae.fold_W_dec_norm()\n",
+    "\n",
+    "\n",
+    "activations_store = ActivationsStore.from_sae(\n",
+    "    model = model,\n",
+    "    sae = sae,\n",
+    "    streaming=True,\n",
+    "    store_batch_size_prompts=8,\n",
+    "    n_batches_in_buffer=8,\n",
+    "    device=\"cpu\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from tqdm import tqdm \n",
+    "\n",
+    "def get_tokens(\n",
+    "    activations_store: ActivationsStore,\n",
+    "    n_batches_to_sample_from: int = 4096 * 6,\n",
+    "    n_prompts_to_select: int = 4096 * 6,\n",
+    "):\n",
+    "    all_tokens_list = []\n",
+    "    pbar = tqdm(range(n_batches_to_sample_from))\n",
+    "    for _ in pbar:\n",
+    "        batch_tokens = activations_store.get_batch_tokens()\n",
+    "        batch_tokens = batch_tokens[torch.randperm(batch_tokens.shape[0])][\n",
+    "            : batch_tokens.shape[0]\n",
+    "        ]\n",
+    "        all_tokens_list.append(batch_tokens)\n",
+    "\n",
+    "    all_tokens = torch.cat(all_tokens_list, dim=0)\n",
+    "    all_tokens = all_tokens[torch.randperm(all_tokens.shape[0])]\n",
+    "    return all_tokens[:n_prompts_to_select]\n",
+    "\n",
+    "# 1000 prompts is plenty for a demo.\n",
+    "# token_dataset = get_tokens(activations_store)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# torch.save(token_dataset, \"token_dataset.pt\")\n",
+    "token_dataset = torch.load(\"token_dataset.pt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os \n",
+    "os.rmdir(\"demo_activations_cache\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "test_feature_idx_gpt = list(range(256))\n",
+    "\n",
+    "feature_vis_config_gpt = sae_dashboard.SaeVisConfig(\n",
+    "    hook_point=sae.cfg.hook_name,\n",
+    "    features=test_feature_idx_gpt,\n",
+    "    minibatch_size_features=16,\n",
+    "    minibatch_size_tokens=32, # this is really prompt with the number of tokens determined by the sequence length\n",
+    "    verbose=True,\n",
+    "    device=\"cuda\",\n",
+    "    cache_dir=Path(\"demo_activations_cache\"), # this will enable us to skip running the model for subsequent features.\n",
+    "    dtype=\"bfloat16\",\n",
+    ")\n",
+    "\n",
+    "runner = sae_dashboard.SaeVisRunner(feature_vis_config_gpt)\n",
+    "\n",
+    "data = runner.run(\n",
+    "    encoder=sae, # type: ignore\n",
+    "    model=model,\n",
+    "    tokens=token_dataset[:4096],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sae_dashboard.data_writing_fns import save_feature_centric_vis\n",
+    "filename = f\"demo_feature_dashboards.html\"\n",
+    "save_feature_centric_vis(sae_vis_data=data, filename=filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quick Profiling experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "activations_store = ActivationsStore.from_sae(\n",
+    "    model = model,\n",
+    "    sae = sae,\n",
+    "    streaming=True,\n",
+    "    store_batch_size_prompts=32,\n",
+    "    n_batches_in_buffer=1,\n",
+    "    device=\"cpu\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sae.cfg.d_in"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gc\n",
+    "import torch\n",
+    "from safetensors.torch import save_file\n",
+    "from torch.profiler import profile, record_function, ProfilerActivity\n",
+    "\n",
+    "gc.collect()\n",
+    "torch.cuda.empty_cache()\n",
+    "@torch.no_grad()\n",
+    "def my_function():\n",
+    "    # Your PyTorch code here\n",
+    "    for _ in range(5):\n",
+    "        tokens = token_dataset[:32]\n",
+    "        _, cache = model.run_with_cache(tokens, stop_at_layer = sae.cfg.hook_layer+1, names_filter = sae.cfg.hook_name)\n",
+    "        sae_in = cache[sae.cfg.hook_name]\n",
+    "        # tensors = {\"activations\": sae_in}\n",
+    "        # save_file(tensors, \"test.safetensors\")\n",
+    "        # del tensors\n",
+    "\n",
+    "\n",
+    "with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True) as prof:\n",
+    "    with record_function(\"my_function\"):\n",
+    "        my_function()\n",
+    "\n",
+    "print(prof.key_averages().table(sort_by=\"cpu_time_total\", row_limit=10))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/acceptance/test_neuronpedia_runner.py
+++ b/tests/acceptance/test_neuronpedia_runner.py
@@ -35,6 +35,47 @@ def test_benchmark_neuronpedia_runner():
         start_batch=0,
         end_batch=8,
         use_wandb=True,
+        sae_device="cpu",
+        model_device="cpu",
+        model_n_devices=1,
+        activation_store_device="cpu",
+    )
+
+    runner = NeuronpediaRunner(cfg)
+    runner.run()
+
+
+# assume we have 4 devices, will put model on first 3, SAE on the last.
+def test_benchmark_neuronpedia_runner_distributed():
+
+    # MODEL_ID = "gpt2-small"
+
+    (_, SAE_WEIGHTS_PATH, _) = download_sae_from_hf(
+        "jbloom/GPT2-Small-SAEs-Reformatted", "blocks.0.hook_resid_pre"
+    )
+
+    NP_OUTPUT_FOLDER = "neuronpedia_outputs/benchmark"
+    SAE_ID = "res-jb"
+    SAE_PATH = os.path.dirname(SAE_WEIGHTS_PATH)
+    print(SAE_PATH)
+
+    # delete output files if present
+    os.system(f"rm -rf {NP_OUTPUT_FOLDER}")
+    cfg = NeuronpediaRunnerConfig(
+        sae_id=SAE_ID,
+        sae_path=SAE_PATH,
+        outputs_dir=NP_OUTPUT_FOLDER,
+        sparsity_threshold=-5,
+        n_batches_to_sample_from=1000,
+        n_prompts_to_select=1000,
+        n_features_at_a_time=32,
+        start_batch=0,
+        end_batch=8,
+        use_wandb=True,
+        sae_device="cuda:3",
+        model_device="cuda",
+        model_n_devices=3,
+        activation_store_device="cpu",
     )
 
     runner = NeuronpediaRunner(cfg)

--- a/tests/acceptance/test_neuronpedia_runner.py
+++ b/tests/acceptance/test_neuronpedia_runner.py
@@ -1,10 +1,11 @@
 import os
 
+from sae_lens.toolkit.pretrained_saes import download_sae_from_hf
+
 from sae_dashboard.neuronpedia.neuronpedia_runner import (
     NeuronpediaRunner,
     NeuronpediaRunnerConfig,
 )
-from sae_lens.toolkit.pretrained_saes import download_sae_from_hf
 
 
 # pytest -s tests/benchmark/test_neuronpedia_runner.py::test_benchmark_neuronpedia_runner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,9 +39,10 @@ def autoencoder() -> SAE:
         activation_fn_str="relu",
         finetuning_scaling_factor=False,
         hook_head_index=None,
-        normalize_activations=False,
+        normalize_activations="none",
         device="cpu",
         sae_lens_training_version=None,
+        dataset_trust_remote_code=True,
     )
 
     autoencoder = SAE(cfg)

--- a/tests/unit/test_sae_vis_runner.py
+++ b/tests/unit/test_sae_vis_runner.py
@@ -3,15 +3,15 @@ from pathlib import Path
 
 import pytest
 from jaxtyping import Int
-from sae_dashboard.components_config import SequencesConfig
-from sae_dashboard.data_writing_fns import save_feature_centric_vis
-from sae_dashboard.sae_vis_data import SaeVisConfig, SaeVisData
-from sae_dashboard.sae_vis_runner import SaeVisRunner
 from sae_lens import SAE
 from syrupy.assertion import SnapshotAssertion
 from torch import Tensor
 from transformer_lens import HookedTransformer
 
+from sae_dashboard.components_config import SequencesConfig
+from sae_dashboard.data_writing_fns import save_feature_centric_vis
+from sae_dashboard.sae_vis_data import SaeVisConfig, SaeVisData
+from sae_dashboard.sae_vis_runner import SaeVisRunner
 from tests.helpers import round_floats_deep
 
 ROOT_DIR = Path(__file__).parent.parent.parent

--- a/tests/unit/test_sequence_data_generator.py
+++ b/tests/unit/test_sequence_data_generator.py
@@ -1,7 +1,7 @@
 import torch
-from sae_dashboard.sequence_data_generator import SequenceDataGenerator
 from transformer_lens import HookedTransformer
 
+from sae_dashboard.sequence_data_generator import SequenceDataGenerator
 from tests.helpers import build_sae_vis_cfg
 
 

--- a/tests/unit/test_util_fns.py
+++ b/tests/unit/test_util_fns.py
@@ -1,4 +1,5 @@
 import torch
+
 from sae_dashboard.utils_fns import RollingCorrCoef, TopK, sample_unique_indices
 
 


### PR DESCRIPTION

@hijohnnylin A PR to make NP runner work with multiple devices. Works for Mistral-7b. It's not super optimized and I think single device with lots of GPU ram is likely best, but at a push, putting the model on all devices except the last, the SAE on the last (as it might be big) will work well. Let me know how this goes. 

See example code below (not in CI, would be nice to have a multi-GPU CI at some point). 

```python
# assume we have 4 devices, will put model on first 3, SAE on the last.
def test_benchmark_neuronpedia_runner_distributed():

    # MODEL_ID = "gpt2-small"

    (_, SAE_WEIGHTS_PATH, _) = download_sae_from_hf(
        "jbloom/GPT2-Small-SAEs-Reformatted", "blocks.0.hook_resid_pre"
    )

    NP_OUTPUT_FOLDER = "neuronpedia_outputs/benchmark"
    SAE_ID = "res-jb"
    SAE_PATH = os.path.dirname(SAE_WEIGHTS_PATH)
    print(SAE_PATH)

    # delete output files if present
    os.system(f"rm -rf {NP_OUTPUT_FOLDER}")
    cfg = NeuronpediaRunnerConfig(
        sae_id=SAE_ID,
        sae_path=SAE_PATH,
        outputs_dir=NP_OUTPUT_FOLDER,
        sparsity_threshold=-5,
        n_batches_to_sample_from=1000,
        n_prompts_to_select=1000,
        n_features_at_a_time=32,
        start_batch=0,
        end_batch=8,
        use_wandb=True,
        sae_device="cuda:3",
        model_device="cuda",
        model_n_devices=3,
        activation_store_device="cpu",
    )

    runner = NeuronpediaRunner(cfg)
    runner.run()

```