### PR TITLE
Dtype should default to SAE's config if not specified

### DIFF
--- a/sae_dashboard/neuronpedia/neuronpedia.py
+++ b/sae_dashboard/neuronpedia/neuronpedia.py
@@ -76,7 +76,7 @@ Enter value from -10 to 0 [1 to skip]""",
 Override DType type?
 [Enter to use SAE default]""",
         ),
-    ] = "float32",
+    ] = "",
     feat_per_batch: Annotated[
         int,
         typer.Option(
@@ -167,7 +167,7 @@ Enter -1 to do all batches. Existing batch files will not be overwritten.""",
         device = "cuda"
     sparse_autoencoder = SAE.load_from_pretrained(sae_path_string, device=device)
     model_id = sparse_autoencoder.cfg.model_name
-    if dtype is None:
+    if dtype == "":
         dtype = sparse_autoencoder.cfg.dtype
 
     # make the outputs subdirectory if it doesn't exist, ensure it's not a file

--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -174,7 +174,8 @@ class NeuronpediaRunner:
         with open(f"{self.cfg.sae_path}/cfg.json", "r") as f:
             sae_cfg_json = json.load(f)
         sae_from_pretrained_kwargs = sae_cfg_json.get("from_pretrained_kwargs", {})
-        print("SAE Config on disk", sae_cfg_json)
+        print("SAE Config on disk:")
+        print(json.dumps(sae_cfg_json, indent=2))
         if sae_from_pretrained_kwargs != {}:
             print("SAE has from_pretrained_kwargs", sae_from_pretrained_kwargs)
         else:

--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -97,7 +97,7 @@ class NeuronpediaRunnerConfig:
     top_acts_group_size: int = 20
     quantile_group_size: int = 5
 
-    dtype: str = "bfloat16"
+    dtype: str = ""
 
     sae_device: str | None = None
     activation_store_device: str | None = None
@@ -138,6 +138,10 @@ class NeuronpediaRunner:
         # Activation store device is always CPU
         self.cfg.activation_store_device = self.cfg.activation_store_device or "cpu"
 
+        # Default dtype to the SAE dtype unless we override
+        if self.cfg.dtype == "":
+            self.cfg.dtype = self.sae.cfg.dtype
+
         # Initialize SAE
         self.sae = SAE.load_from_pretrained(
             path=self.cfg.sae_path,
@@ -156,6 +160,7 @@ class NeuronpediaRunner:
         print(f"Model Device: {self.cfg.model_device}")
         print(f"Model Num Devices: {self.cfg.model_n_devices}")
         print(f"Activation Store Device: {self.cfg.activation_store_device}")
+        print(f"DType: {self.cfg.dtype}")
         print(f"Dataset Path: {self.cfg.huggingface_dataset_path}")
         print(f"Forward Pass size: {self.cfg.n_tokens_in_prompt}")
 
@@ -180,11 +185,6 @@ class NeuronpediaRunner:
         self.sae.cfg.context_size = self.cfg.n_tokens_in_prompt
 
         self.sae.fold_W_dec_norm()
-        # Default dtype to the SAE dtype unless we override
-        if self.cfg.dtype == "":
-            self.cfg.dtype = self.sae.cfg.dtype
-
-        print(f"DType: {self.cfg.dtype}")
 
         # Initialize Model
         self.model_id = self.sae.cfg.model_name


### PR DESCRIPTION
The recent changes to neuronpedia.py and neuronpedia_runner have changed the behavior of setting dtype. There seems to be two issues:

1) Dtype is being defaulted to float32 or bfloat16 (in two different places), but there doesn't seem to be a reason to prefer those as a default. We should always use the SAE's dtype, unless user explicitly sets one.
2) load_from_pretrained is always forcing an override of the dtype and not allowing a default, fixed in (https://github.com/jbloomAus/SAELens/pull/225)

The fix here is:
1) Remove float32 and bfloat16 as hardcoded default dtypes, and instead use "" to signify that user did not specify a dtype override.
2) Only set dtype in load_from_pretrained if there's an override. otherwise use None (which defaults to the SAE's dtype)
3) Set the dtype for SaeVisConfig to the SAE's dtype if there's no override