### PR TITLE
fix: neuronpedia uses api_key for uploading features, and update sae_id -> sae_set

### DIFF
--- a/sae_dashboard/neuronpedia/neuronpedia.py
+++ b/sae_dashboard/neuronpedia/neuronpedia.py
@@ -414,10 +414,29 @@ def upload(
             prompt="""Resume from batch? (Default: 0)""",
         ),
     ] = 0,
+    upload_dead_stubs: Annotated[
+        bool,
+        typer.Option(
+            prompt="""Upload dead stubs? (Default: True)""",
+        ),
+    ] = True,
 ):
     """
     This will upload features that were generated to Neuronpedia. It currently only works if you have admin access to a Neuronpedia instance via localhost:3000.
     """
+
+    if upload_dead_stubs:
+        skipped_path = os.path.join(outputs_dir, "skipped_indexes.json")
+        f = open(skipped_path, "r")
+        data = json.load(f)
+        url = host + "/api/local/upload-skipped-features"
+        result = requests.post(
+            url,
+            json=data,
+            headers={"x-api-key": api_key},
+        )
+        if result.status_code != 200:
+            raise Exception(f"Upload failed with status code: {result.status_code}")
 
     files_to_upload = list(outputs_dir.glob("batch-*.json"))
 
@@ -439,11 +458,13 @@ def upload(
         data = json.load(f, parse_constant=NanAndInfReplacer)
 
         url = host + "/api/local/upload-features"
-        requests.post(
+        result = requests.post(
             url,
             json=data,
             headers={"x-api-key": api_key},
         )
+        if result.status_code != 200:
+            raise Exception(f"Upload failed with status code: {result.status_code}")
 
     print(
         Align.center(
@@ -452,58 +473,6 @@ def upload(
 {len(files_to_upload)} batch files uploaded to Neuronpedia.
 """,
                 title="Uploads Complete",
-            )
-        )
-    )
-
-
-@app.command()
-def upload_dead_stubs(
-    outputs_dir: Annotated[
-        Path,
-        typer.Option(
-            exists=True,
-            dir_okay=True,
-            readable=True,
-            resolve_path=True,
-            prompt="What is the absolute local file path to the feature outputs directory?",
-        ),
-    ],
-    api_key: Annotated[
-        str,
-        typer.Option(
-            prompt="""Your Neuronpedia API key? (input will be hidden)""",
-            hide_input=True,
-        ),
-    ],
-    host: Annotated[
-        str,
-        typer.Option(
-            prompt="""Host to upload to? (Default: http://localhost:3000)""",
-        ),
-    ] = "http://localhost:3000",
-):
-    """
-    This will create "There are no activations for this feature" stubs for dead features on Neuronpedia.  It currently only works if you have admin access to a Neuronpedia instance via localhost:3000.
-    """
-
-    skipped_path = os.path.join(outputs_dir, "skipped_indexes.json")
-    f = open(skipped_path, "r")
-    data = json.load(f)
-    url = host + "/api/local/upload-skipped-features"
-    requests.post(
-        url,
-        json=data,
-        headers={"x-api-key": api_key},
-    )
-
-    print(
-        Align.center(
-            Panel(
-                """
-Dead feature stubs created.
-""",
-                title="Complete",
             )
         )
     )

--- a/sae_dashboard/neuronpedia/neuronpedia.py
+++ b/sae_dashboard/neuronpedia/neuronpedia.py
@@ -395,6 +395,13 @@ def upload(
             prompt="What is the absolute local file path to the feature outputs directory?",
         ),
     ],
+    api_key: Annotated[
+        str,
+        typer.Option(
+            prompt="""Your Neuronpedia API key? (input will be hidden)""",
+            hide_input=True,
+        ),
+    ],
     host: Annotated[
         str,
         typer.Option(
@@ -435,6 +442,7 @@ def upload(
         requests.post(
             url,
             json=data,
+            headers={"x-api-key": api_key},
         )
 
     print(
@@ -461,6 +469,13 @@ def upload_dead_stubs(
             prompt="What is the absolute local file path to the feature outputs directory?",
         ),
     ],
+    api_key: Annotated[
+        str,
+        typer.Option(
+            prompt="""Your Neuronpedia API key? (input will be hidden)""",
+            hide_input=True,
+        ),
+    ],
     host: Annotated[
         str,
         typer.Option(
@@ -479,6 +494,7 @@ def upload_dead_stubs(
     requests.post(
         url,
         json=data,
+        headers={"x-api-key": api_key},
     )
 
     print(

--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import torch
-import wandb
 from matplotlib import colors
 from sae_lens.sae import SAE
 from sae_lens.toolkit.pretrained_saes import load_sparsity
@@ -14,6 +13,7 @@ from sae_lens.training.activations_store import ActivationsStore
 from tqdm import tqdm
 from transformer_lens import HookedTransformer
 
+import wandb
 from sae_dashboard.components_config import (
     ActsHistogramConfig,
     Column,
@@ -324,7 +324,7 @@ class NeuronpediaRunner:
             {
                 "model_id": self.model_id,
                 "layer": str(self.layer),
-                "sae_id": self.cfg.sae_set,
+                "sae_set": self.cfg.sae_set,
                 "log_sparsity": self.cfg.sparsity_threshold,
                 "skipped_indexes": list(skipped_indexes),
             }


### PR DESCRIPTION
- neuronpedia uses api_key for uploading features
- update sae_id -> sae_set