### PR TITLE
Ignore bos option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ rich = "^13.7.1"
 matplotlib = "^3.8.4"
 safetensors = "^0.4.3"
 typer = "^0.12.3"
-sae-lens = "^3.12.0"
+sae-lens = "^3.14.0"
 isort = "^5.13.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/sae_dashboard/feature_data_generator.py
+++ b/sae_dashboard/feature_data_generator.py
@@ -246,6 +246,24 @@ class FeatureMaskingContext:
             # set the weight
             setattr(self.sae, "b_enc", nn.Parameter(masked_weight))
 
+        elif self.sae.cfg.architecture == "jumprelu":
+
+            ## b_enc
+            self.original_weight["b_enc"] = getattr(self.sae, "b_enc").data.clone()
+            # mask the weight
+            masked_weight = self.sae.b_enc[self.feature_idxs]
+            # set the weight
+            setattr(self.sae, "b_enc", nn.Parameter(masked_weight))
+
+            ## threshold
+            self.original_weight["threshold"] = getattr(
+                self.sae, "threshold"
+            ).data.clone()
+            # mask the weight
+            masked_weight = self.sae.threshold[self.feature_idxs]
+            # set the weight
+            setattr(self.sae, "threshold", nn.Parameter(masked_weight))
+
         elif self.sae.cfg.architecture == "gated":
 
             ## b_gate

--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -448,6 +448,7 @@ class NeuronpediaRunner:
                     perform_ablation_experiments=False,
                     dtype=self.cfg.dtype,
                     cache_dir=self.cached_activations_dir,
+                    ignore_tokens={self.model.tokenizer.pad_token_id, self.model.tokenizer.bos_token_id, self.model.tokenizer.eos_token_id},  # type: ignore
                 )
 
                 feature_data = SaeVisRunner(feature_vis_config_gpt).run(

--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import torch
+import wandb
 from matplotlib import colors
 from sae_lens.sae import SAE
 from sae_lens.toolkit.pretrained_saes import load_sparsity
@@ -13,7 +14,6 @@ from sae_lens.training.activations_store import ActivationsStore
 from tqdm import tqdm
 from transformer_lens import HookedTransformer
 
-import wandb
 from sae_dashboard.components_config import (
     ActsHistogramConfig,
     Column,

--- a/sae_dashboard/sae_vis_data.py
+++ b/sae_dashboard/sae_vis_data.py
@@ -37,6 +37,7 @@ class SaeVisConfig:
     perform_ablation_experiments: bool = False
     device: str = "cpu"
     dtype: str = "float32"
+    ignore_tokens: set[int] = field(default_factory=set)
 
     # Vis
     feature_centric_layout: SaeVisLayoutConfig = field(

--- a/sae_dashboard/sae_vis_runner.py
+++ b/sae_dashboard/sae_vis_runner.py
@@ -150,7 +150,17 @@ class SaeVisRunner:
 
                 # Get data for feature activations histogram (including the title!)
                 feat_acts = all_feat_acts[..., i]
-                nonzero_feat_acts = feat_acts[feat_acts > 0]
+
+                # ignore any tokens in self.cfg.ignore_tokens
+                ignore_tokens_mask = ~torch.isin(
+                    tokens,
+                    torch.tensor(
+                        list(self.cfg.ignore_tokens),
+                        dtype=tokens.dtype,
+                        device=tokens.device,
+                    ),
+                )
+                nonzero_feat_acts = feat_acts[(feat_acts > 0) & (ignore_tokens_mask)]
                 frac_nonzero = nonzero_feat_acts.numel() / feat_acts.numel()
                 feature_data_dict[feat].acts_histogram_data = (
                     ActsHistogramData.from_data(

--- a/sae_dashboard/utils_fns.py
+++ b/sae_dashboard/utils_fns.py
@@ -1075,10 +1075,10 @@ class HistogramData:
             tick_vals = [round(t, 1) for t in tick_vals]
 
         return cls(  # type: ignore
-            bar_heights=bar_heights,
-            bar_values=bar_values,
-            tick_vals=tick_vals,
-            title=title,
+            bar_heights=bar_heights,  # type: ignore
+            bar_values=bar_values,  # type: ignore
+            tick_vals=tick_vals,  # type: ignore
+            title=title,  # type: ignore
         )
 
 

--- a/tests/unit/test_feature_mask_context.py
+++ b/tests/unit/test_feature_mask_context.py
@@ -16,4 +16,4 @@ def test_feature_mask_context(autoencoder: SAE):
     with FeatureMaskingContext(autoencoder, feature_indices):
         new_feature_acts = autoencoder.encode(sae_in_mock)
 
-    assert (original_feature_acts - new_feature_acts).max() <= 1e-6
+    assert (original_feature_acts - new_feature_acts).max() <= 1e-5


### PR DESCRIPTION
1. Sets an option to ignore bos / eos / pad token ids in SAE Vis Runner
2. Always ignores these in neuronpedia runner. 