### PR TITLE
fix: restore hook_z support following regression.

### DIFF
--- a/sae_dashboard/sae_vis_runner.py
+++ b/sae_dashboard/sae_vis_runner.py
@@ -55,6 +55,10 @@ class SaeVisRunner:
         # encoder = self.mock_feature_acts_subset_for_now(encoder)
         encoder.fold_W_dec_norm()
 
+        # turn off reshaping mode since that's not useful if we're caching activations on disk
+        if encoder.hook_z_reshaping_mode:
+            encoder.turn_off_forward_pass_hook_z_reshaping()
+
         # set precision on encoders and model
         # encoder = encoder.to(DTYPES[self.cfg.dtype])
         # # model = cast(HookedTransformer, model.to(DTYPES[self.cfg.dtype]))

--- a/sae_dashboard/transformer_lens_wrapper.py
+++ b/sae_dashboard/transformer_lens_wrapper.py
@@ -92,6 +92,10 @@ class TransformerLensWrapper(nn.Module):
 
         # The hook functions work by storing data in model's hook context, so we pop them back out
         activation: Tensor = self.model.hook_dict[self.hook_point].ctx.pop("activation")
+        
+        if "hook_z" in self.hook_point:
+            activation = activation.flatten(-2, -1)
+        
         # if self.hook_point_resid_final == self.hook_point:
         #     residual: Tensor = activation
         # else:
@@ -118,6 +122,9 @@ class TransformerLensWrapper(nn.Module):
     def W_out(self):
         return self.model.W_out
 
+    @property
+    def W_O(self):
+        return self.model.W_O
 
 def to_resid_dir(dir: Float[Tensor, "feats d_in"], model: TransformerLensWrapper):
     """
@@ -136,6 +143,9 @@ def to_resid_dir(dir: Float[Tensor, "feats d_in"], model: TransformerLensWrapper
     # If it was trained on the MLP layer, then we apply the W_out map
     elif ("pre" in model.hook_point) or ("post" in model.hook_point):
         return dir @ model.W_out[model.hook_layer]
+
+    elif "hook_z" in model.hook_point:
+        return dir @ model.W_O[model.hook_layer].flatten(0, 1).to(dir.dtype)
 
     # Others not yet supported
     else:

--- a/sae_dashboard/transformer_lens_wrapper.py
+++ b/sae_dashboard/transformer_lens_wrapper.py
@@ -92,10 +92,10 @@ class TransformerLensWrapper(nn.Module):
 
         # The hook functions work by storing data in model's hook context, so we pop them back out
         activation: Tensor = self.model.hook_dict[self.hook_point].ctx.pop("activation")
-        
+
         if "hook_z" in self.hook_point:
             activation = activation.flatten(-2, -1)
-        
+
         # if self.hook_point_resid_final == self.hook_point:
         #     residual: Tensor = activation
         # else:
@@ -125,6 +125,7 @@ class TransformerLensWrapper(nn.Module):
     @property
     def W_O(self):
         return self.model.W_O
+
 
 def to_resid_dir(dir: Float[Tensor, "feats d_in"], model: TransformerLensWrapper):
     """

--- a/tests/acceptance/test_neuronpedia_runner.py
+++ b/tests/acceptance/test_neuronpedia_runner.py
@@ -286,3 +286,39 @@ def test_benchmark_neuronpedia_runner_distributed():
 
     runner = NeuronpediaRunner(cfg)
     runner.run()
+
+
+def test_simple_neuronpedia_runner_hook_z_sae():
+
+    NP_OUTPUT_FOLDER = "neuronpedia_outputs/test_attn"
+    ACT_CACHE_FOLDER = "cached_activations"
+    SAE_SET = "gpt2-small-hook-z-kk"
+    SAE_PATH = "blocks.0.hook_z"
+    NUM_FEATURES_PER_BATCH = 2
+    NUM_BATCHES = 2
+
+    # delete output files if present
+    os.system(f"rm -rf {NP_OUTPUT_FOLDER}")
+    os.system(f"rm -rf {ACT_CACHE_FOLDER}")
+
+    # # we make two batches of 2 features each
+    cfg = NeuronpediaRunnerConfig(
+        sae_set=SAE_SET,
+        sae_path=SAE_PATH,
+        np_set_name="att-kk",
+        from_local_sae=False,
+        outputs_dir=NP_OUTPUT_FOLDER,
+        sparsity_threshold=1,
+        n_prompts_total=5000,
+        n_features_at_a_time=NUM_FEATURES_PER_BATCH,
+        n_prompts_in_forward_pass=32,
+        start_batch=0,
+        end_batch=NUM_BATCHES - 1,
+        use_wandb=True,
+        shuffle_tokens=False,
+    )
+
+    runner = NeuronpediaRunner(cfg)
+    runner.run()
+
+    assert "run_settings.json" in os.listdir(runner.cfg.outputs_dir)


### PR DESCRIPTION
Hook Z reshaping went unnoticed (SAE Lens made a change that was untested here). Just needed to turn off automatic reshaping. 