### PR TITLE
Added float16 version of quantile calculation

### DIFF
--- a/tests/unit/test_util_fns.py
+++ b/tests/unit/test_util_fns.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 import torch
-from torch.profiler import ProfilerActivity, profile, record_function
 
 from sae_dashboard.utils_fns import (
     FeatureStatistics,
@@ -9,6 +8,9 @@ from sae_dashboard.utils_fns import (
     TopK,
     sample_unique_indices,
 )
+
+# from torch.profiler import ProfilerActivity, profile, record_function
+
 
 SYMMETRIC_RANGES_AND_PRECISIONS: list[tuple[list[float], int]] = [
     ([0.0, 0.01], 5),

--- a/tests/unit/test_util_fns.py
+++ b/tests/unit/test_util_fns.py
@@ -106,7 +106,7 @@ def test_TopK_without_mask_smallest():
     assert topk.indices.tolist() == [0, 1, 2]
 
 
-def test_feature_statistics_create(precision_data):
+def test_feature_statistics_create(precision_data: tuple[torch.Tensor, torch.dtype]):
     data, dtype = precision_data
 
     # Create FeatureStatistics object


### PR DESCRIPTION
Data passed into the create() function of the FeatureStatistics object will now use a float16 function to calculate quantiles, IF the activation data was originally in float16. Other precisions will behave as they did previously.

I've added new tests to verify that this float16 version is reasonably close to the old version, which was converting float16 to float32, and also tests that cover other aspects of the create() function.