### PR TITLE
Quantile OOM prevention

### DIFF
--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -93,6 +93,7 @@ class NeuronpediaRunnerConfig:
 
     # batching
     n_features_at_a_time: int = 128
+    quantile_feature_batch_size: int = 64
     start_batch: int = 0
     end_batch: Optional[int] = None
 
@@ -503,6 +504,7 @@ class NeuronpediaRunner:
                     features=features_to_process,
                     minibatch_size_features=self.cfg.n_features_at_a_time,
                     minibatch_size_tokens=self.cfg.n_prompts_in_forward_pass,
+                    quantile_feature_batch_size=self.cfg.quantile_feature_batch_size,
                     verbose=True,
                     device=self.cfg.sae_device or DEFAULT_FALLBACK_DEVICE,
                     feature_centric_layout=layout,

--- a/sae_dashboard/sae_vis_data.py
+++ b/sae_dashboard/sae_vis_data.py
@@ -34,6 +34,7 @@ class SaeVisConfig:
     features: Iterable[int]
     minibatch_size_features: int = 256
     minibatch_size_tokens: int = 64
+    quantile_feature_batch_size: int = 64
     perform_ablation_experiments: bool = False
     device: str = "cpu"
     dtype: str = "float32"

--- a/sae_dashboard/sae_vis_runner.py
+++ b/sae_dashboard/sae_vis_runner.py
@@ -109,8 +109,11 @@ class SaeVisRunner:
             ).to(self.device)
 
             # ! Get stats (including quantiles, which will be useful for the prompt-centric visualisation)
+            print(f"all_feat_acts dtype: {all_feat_acts.dtype}")
+            print(f"all_feat_acts shape: {all_feat_acts.shape}")
             feature_stats = FeatureStatistics.create(
-                data=einops.rearrange(all_feat_acts, "b s feats -> feats (b s)")
+                data=einops.rearrange(all_feat_acts, "b s feats -> feats (b s)"),
+                batch_size=self.cfg.quantile_feature_batch_size,
             )
 
             # ! Data setup code (defining the main objects we'll eventually return)

--- a/tests/unit/test_util_fns.py
+++ b/tests/unit/test_util_fns.py
@@ -42,8 +42,13 @@ def precision_data(request):  # type:ignore
 
 @pytest.fixture(params=[torch.float16, torch.float32, torch.float64])
 def large_precision_data(request):  # type:ignore
+    # check if cuda is available, and if so, set device to this
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    else:
+        device = torch.device("cpu")
     # Create some sample data
-    data = torch.randn(100, 1000, device="cuda", dtype=request.param)
+    data = torch.randn(100, 1000, device=device, dtype=request.param)
     return data, request.param
 
 

--- a/tests/unit/test_util_fns.py
+++ b/tests/unit/test_util_fns.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 import torch
-from torch.profiler import ProfilerActivity, profile, record_function
 
 from sae_dashboard.utils_fns import (
     FeatureStatistics,
@@ -9,6 +8,9 @@ from sae_dashboard.utils_fns import (
     TopK,
     sample_unique_indices,
 )
+
+# from torch.profiler import ProfilerActivity, profile, record_function
+
 
 SYMMETRIC_RANGES_AND_PRECISIONS: list[tuple[list[float], int]] = [
     ([0.0, 0.01], 5),

--- a/tests/unit/test_util_fns.py
+++ b/tests/unit/test_util_fns.py
@@ -106,7 +106,7 @@ def test_TopK_without_mask_smallest():
     assert topk.indices.tolist() == [0, 1, 2]
 
 
-def test_feature_statistics_create(precision_data):
+def test_feature_statistics_create(precision_data: tuple[torch.Tensor, torch.dtype]):
     data, dtype = precision_data
 
     # Create FeatureStatistics object


### PR DESCRIPTION
Added another test and a parameter (available through the neuronpedia runner and the saevis runner) to set the quantile calculation feature batch size. This prevents OOMS even with the following settings, if that quantile batch size is set lower (e.g. to 64):

```# NP SET NAME
NP_SET_NAME = "gemmascope-res-65k"
SAE_SET = "gemma-scope-2b-pt-res-canonical"
SAE_PATH = "layer_0/width_65k/canonical"

# DATAEST
HF_DATASET_PATH = "monology/pile-uncopyrighted"


SPARSITY_THRESHOLD = 1

# IMPORTANT
SAE_DTYPE = "float32"
MODEL_DTYPE = "bfloat16"

# PERFORMANCE SETTING
N_PROMPTS = 98304
N_TOKENS_IN_PROMPT = 128
N_PROMPTS_IN_FORWARD_PASS = 256
NUM_FEATURES_PER_BATCH = 128```