### PR TITLE
fix: added mem cleanup

### DIFF
--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import gc
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Set, Tuple
@@ -422,7 +423,7 @@ class NeuronpediaRunner:
             for feature_batch_count, features_to_process in tqdm(
                 enumerate(feature_idx)
             ):
-
+                
                 if feature_batch_count < self.cfg.start_batch:
                     feature_batch_count = feature_batch_count + 1
                     continue
@@ -523,7 +524,11 @@ class NeuronpediaRunner:
                         {"batch": feature_batch_count},
                         step=feature_batch_count,
                     )
-
+                # Clean up after each batch
+                del feature_data
+                gc.collect()
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
         if self.cfg.use_wandb:
             wandb.sdk.finish()
 

--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -1,7 +1,7 @@
 import argparse
+import gc
 import json
 import os
-import gc
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Set, Tuple
@@ -423,7 +423,7 @@ class NeuronpediaRunner:
             for feature_batch_count, features_to_process in tqdm(
                 enumerate(feature_idx)
             ):
-                
+
                 if feature_batch_count < self.cfg.start_batch:
                     feature_batch_count = feature_batch_count + 1
                     continue


### PR DESCRIPTION
At the end of a neuronpedia runner batch cycle, the runner will now clear system and GPU RAM. This enables the usage of more prompts while retaining large batch sizes (e.g., 35k prompts, 128 context length, 256 prompts per batch, 256 features per batch for Gemma 2 2B attention, which was previously getting killed due to memory errors).