### PR TITLE
Fix/topk selection purview

### DIFF
--- a/sae_dashboard/feature_data_generator.py
+++ b/sae_dashboard/feature_data_generator.py
@@ -17,6 +17,7 @@ from sae_dashboard.transformer_lens_wrapper import (
     to_resid_direction,
 )
 from sae_dashboard.utils_fns import RollingCorrCoef
+from sae_lens.sae import TopK
 
 Arr = np.ndarray
 
@@ -87,11 +88,16 @@ class FeatureDataGenerator:
                 self.encoder.device
             )  # make sure acts are on the correct device
 
-            # Compute feature activations from this
-            with FeatureMaskingContext(self.encoder, feature_indices):
-                feature_acts = self.encoder.encode(primary_acts).to(
-                    DTYPES[self.cfg.dtype]
-                )
+            # For TopK, compute all activations first, then select features
+            if isinstance(self.encoder.activation_fn, TopK):
+                # Get all features' activations
+                all_features_acts = self.encoder.encode(primary_acts)
+                # Then select only the features we're interested in
+                feature_acts = all_features_acts[:, :, feature_indices].to(DTYPES[self.cfg.dtype])
+            else:
+                # For other activation functions, use the masking context
+                with FeatureMaskingContext(self.encoder, feature_indices):
+                    feature_acts = self.encoder.encode(primary_acts).to(DTYPES[self.cfg.dtype])
 
             self.update_rolling_coefficients(
                 model_acts=primary_acts,

--- a/sae_dashboard/feature_data_generator.py
+++ b/sae_dashboard/feature_data_generator.py
@@ -7,6 +7,7 @@ import torch
 from jaxtyping import Float, Int
 from sae_lens import SAE
 from sae_lens.config import DTYPE_MAP as DTYPES
+from sae_lens.sae import TopK
 from torch import Tensor, nn
 from tqdm.auto import tqdm
 
@@ -17,7 +18,6 @@ from sae_dashboard.transformer_lens_wrapper import (
     to_resid_direction,
 )
 from sae_dashboard.utils_fns import RollingCorrCoef
-from sae_lens.sae import TopK
 
 Arr = np.ndarray
 
@@ -93,11 +93,15 @@ class FeatureDataGenerator:
                 # Get all features' activations
                 all_features_acts = self.encoder.encode(primary_acts)
                 # Then select only the features we're interested in
-                feature_acts = all_features_acts[:, :, feature_indices].to(DTYPES[self.cfg.dtype])
+                feature_acts = all_features_acts[:, :, feature_indices].to(
+                    DTYPES[self.cfg.dtype]
+                )
             else:
                 # For other activation functions, use the masking context
                 with FeatureMaskingContext(self.encoder, feature_indices):
-                    feature_acts = self.encoder.encode(primary_acts).to(DTYPES[self.cfg.dtype])
+                    feature_acts = self.encoder.encode(primary_acts).to(
+                        DTYPES[self.cfg.dtype]
+                    )
 
             self.update_rolling_coefficients(
                 model_acts=primary_acts,

--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -8,6 +8,8 @@ from typing import Dict, Set, Tuple
 
 import numpy as np
 import torch
+import wandb
+import wandb.sdk
 from matplotlib import colors
 from sae_lens.sae import SAE
 from sae_lens.toolkit.pretrained_saes import load_sparsity
@@ -15,8 +17,6 @@ from sae_lens.training.activations_store import ActivationsStore
 from tqdm import tqdm
 from transformer_lens import HookedTransformer
 
-import wandb
-import wandb.sdk
 from sae_dashboard.components_config import (
     ActsHistogramConfig,
     Column,

--- a/scripts/run_dashboards_runpod.py
+++ b/scripts/run_dashboards_runpod.py
@@ -61,7 +61,7 @@ for saelens_sae_id, saelens_np_id in list_of_saes:
 
     def find_saelens_release_from_neuronpedia_id(neuronpedia_id: str) -> str:
         for release, item in directory.items():
-            for _, np_id in item.neuronpedia_id.items():
+            for _, np_id in item.neuronpedia_id.items():  # type: ignore
                 if np_id == neuronpedia_id:
                     return release
         raise ValueError(f"Neuronpedia ID {neuronpedia_id} not found")


### PR DESCRIPTION
This commit will fix an issue we encountered where the TopK activation function does not select the top K latents over the entire SAE width but rather only over an individual batch of latents. It should also solve issues where K is higher than the size of the batch of latents.