### PR TITLE
fix: limit quantile to max 16 million elements

### DIFF
--- a/sae_dashboard/utils_fns.py
+++ b/sae_dashboard/utils_fns.py
@@ -295,6 +295,10 @@ HTML_ALL_REVERSED = {
     **HTML_ANOMALIES_REVERSED,
 }
 
+# torch.quantile crashes if you pass a tensor with more than 16 million elements
+# see: https://github.com/pytorch/pytorch/issues/64947
+MAX_QUANTILE = 2**24 - 1
+
 
 def process_str_tok(str_tok: str, html: bool = True) -> str:
     """
@@ -617,7 +621,7 @@ class FeatureStatistics:
             )
 
             batch_quantile_data = torch.quantile(
-                batch.to(torch.float32),
+                batch[:, :MAX_QUANTILE].to(torch.float32),
                 quantiles_tensor.to(torch.float32),
                 dim=-1,
             )


### PR DESCRIPTION
If you try to generate a dashboard with more too many prompts / tokens, `torch.quantile` crashes because there's randomly a max tensor size of 16 million elements that you're allowed to pass to that function. This PR just truncates the tensor that gets passed to torch.quantile at 16 million to avoid crashing.

For more info, see https://github.com/pytorch/pytorch/issues/64947 