### PR TITLE
feat: allow outputting raw vector in neuronpedia outputs

### DIFF
--- a/sae_dashboard/neuronpedia/neuronpedia_converter.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_converter.py
@@ -383,7 +383,5 @@ class NeuronpediaConverter:
             batch_data.sae_set = vector_set_name
             # No sae_id_suffix needed for vectors
 
-        print("FEATURES OUTPUTS: ")
-        print(features_outputs[0].vector)
         batch_data.features = features_outputs
         return batch_data

--- a/sae_dashboard/neuronpedia/neuronpedia_converter.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_converter.py
@@ -1,7 +1,8 @@
 import json
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
+import torch
 from transformer_lens import HookedTransformer
 
 from sae_dashboard.feature_data import FeatureData
@@ -81,6 +82,7 @@ class NeuronpediaConverter:
         vis_data: Union[SaeVisData, VectorVisData],
         np_cfg: Union[NeuronpediaRunnerConfig, NeuronpediaVectorRunnerConfig],
         vocab_dict: Dict[int, str],
+        original_vectors: Optional[torch.Tensor] = None,
     ) -> str:
         """
         Convert SaeVisData to Neuronpedia JSON format.
@@ -99,7 +101,7 @@ class NeuronpediaConverter:
             data_dict = vis_data.feature_data_dict
 
         features_outputs = NeuronpediaConverter._process_features(
-            model, data_dict, np_cfg, vocab_dict
+            model, data_dict, np_cfg, vocab_dict, original_vectors
         )
         batch_data = NeuronpediaConverter._create_batch_data(np_cfg, features_outputs)
         return json.dumps(batch_data, cls=NpEncoder)
@@ -110,6 +112,7 @@ class NeuronpediaConverter:
         data_dict: Dict[int, FeatureData],  # Update to use data_dict directly
         np_cfg: Union[NeuronpediaRunnerConfig, NeuronpediaVectorRunnerConfig],
         vocab_dict: Dict[int, str],
+        original_vectors: Optional[torch.Tensor] = None,
     ) -> List[NeuronpediaDashboardFeature]:
         """Process all features and create NeuronpediaDashboardFeature objects."""
         features_outputs = []
@@ -134,6 +137,9 @@ class NeuronpediaConverter:
             feature_output.n_prompts_total = np_cfg.n_prompts_total
             feature_output.n_tokens_in_prompt = np_cfg.n_tokens_in_prompt
             feature_output.dataset = np_cfg.huggingface_dataset_path
+
+            if original_vectors is not None:
+                feature_output.vector = original_vectors[feature_index].tolist()
 
             features_outputs.append(feature_output)
         return features_outputs
@@ -377,5 +383,7 @@ class NeuronpediaConverter:
             batch_data.sae_set = vector_set_name
             # No sae_id_suffix needed for vectors
 
+        print("FEATURES OUTPUTS: ")
+        print(features_outputs[0].vector)
         batch_data.features = features_outputs
         return batch_data

--- a/sae_dashboard/neuronpedia/neuronpedia_dashboard.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_dashboard.py
@@ -126,6 +126,7 @@ class NeuronpediaDashboardFeature:
         dataset: str = "",
         activations: list[dict[str, Any]] = [],
         decoder_weights_dist: list[float] = [],
+        vector: list[float] = [],
     ):
         self.feature_index = feature_index
         self.neuron_alignment_indices = neuron_alignment_indices
@@ -151,6 +152,7 @@ class NeuronpediaDashboardFeature:
         self.dataset = dataset
         self.activations: list[NeuronpediaDashboardActivation] = []
         self.decoder_weights_dist = decoder_weights_dist
+        self.vector = vector
         for activation in activations:
             self.activations.append(NeuronpediaDashboardActivation(**activation))
 
@@ -284,6 +286,7 @@ class NeuronpediaDashboardFeature:
             "dataset": self.dataset,
             "decoder_weights_dist": self.decoder_weights_dist,
             "activations": [activation.to_dict() for activation in self.activations],
+            "vector": self.vector,
         }
 
 

--- a/sae_dashboard/neuronpedia/neuronpedia_runner_config.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner_config.py
@@ -77,6 +77,7 @@ class NeuronpediaVectorRunnerConfig:
 
     # additional calculations
     use_dfa: bool = False
+    include_original_vectors_in_output: bool = False
 
     # Quantile parameters for activation analysis
     n_quantiles: int = 5

--- a/sae_dashboard/neuronpedia/neuronpedia_vector_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_vector_runner.py
@@ -456,8 +456,17 @@ class NeuronpediaVectorRunner:
 
                 self.cfg.model_id = self.model_id
                 self.cfg.layer = self.layer
+                # add the original vectors if include_original_vectors_in_output is True
                 json_object = NeuronpediaConverter.convert_to_np_json(
-                    self.model, vector_data, self.cfg, self.vocab_dict
+                    self.model,
+                    vector_data,
+                    self.cfg,
+                    self.vocab_dict,
+                    (
+                        self.vector_set.vectors
+                        if self.cfg.include_original_vectors_in_output
+                        else None
+                    ),
                 )
                 with open(
                     output_file,


### PR DESCRIPTION
this adds a flag `include_original_vectors_in_output` to `NeuronpediaVectorRunnerConfig` which adds the raw vector to the output batch files.