### PR TITLE
fix: reading model_from_pretrained_kwargs from SAELens config with th…

### DIFF
--- a/sae_dashboard/neuronpedia/neuronpedia_runner.py
+++ b/sae_dashboard/neuronpedia/neuronpedia_runner.py
@@ -154,7 +154,7 @@ class NeuronpediaRunner:
         # get the sae's cfg and check if it has from pretrained kwargs
         # with open(f"{self.cfg.sae_path}/cfg.json", "r") as f:
         sae_cfg_json = self.sae.cfg.to_dict()
-        sae_from_pretrained_kwargs = sae_cfg_json.get("from_pretrained_kwargs", {})
+        sae_from_pretrained_kwargs = sae_cfg_json.get("model_from_pretrained_kwargs", {})
         print("SAE Config on disk:")
         print(json.dumps(sae_cfg_json, indent=2))
         if sae_from_pretrained_kwargs != {}:


### PR DESCRIPTION
…e correct key.

SAELens uses `model_from_pretrained_kwargs` to indicate specific HookedTransformer.from_pretrained() arguments for an SAE(code [here](https://github.com/jbloomAus/SAELens/blob/ffa436c5daa49d78933da45695e6c6817474d7f7/sae_lens/sae.py#L68)). While currently neuronpedia runner uses `from_pretrained_kwargs` to get these config from SAE.cfg. This PR fix this and now it works as expected.