### PR TITLE
upgrades python-semantic-release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v8.0.7
+        uses: python-semantic-release/python-semantic-release@v9.8.8
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Upgrades `python-semantic-release` to v9. Currently, the build/release job will fail with
```
  ERROR: failed to build: failed to solve: process "/bin/sh -c echo \"deb http://deb.debian.org/debian bullseye-backports main\" >> /etc/apt/sources.list;     apt-get update;    apt-get install -y git/bullseye-backports" did not complete successfully: exit code: 100
``` 
.