### PR TITLE
fix: relax saelens to not break saelens demo project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ rich = "^13.7.1"
 matplotlib = "^3.8.4"
 safetensors = "^0.4.3"
 typer = "^0.12.3"
-sae-lens = "^5.0.0"
+sae-lens = ">=5.0.0"
 
 [tool.poetry.group.dev.dependencies]
 isort = "^5.13.2"


### PR DESCRIPTION
Fixes an issue where a notebook from SAELens was breaking due to strict saelens dependency here of v5. We allow v6 in the change.

Affected notebook: https://github.com/jbloomAus/SAELens/blob/main/tutorials/basic_loading_and_analysing.ipynb